### PR TITLE
productos fix

### DIFF
--- a/src/controllers/productController.ts
+++ b/src/controllers/productController.ts
@@ -246,10 +246,10 @@ export const actualizarProducto = async (req: Request, res: Response) => {
     producto.precio = precioValidado;
     producto.divisa = divisa ?? producto.divisa;
     producto.descuento = descuento ?? producto.descuento;
-    producto.rubro_id = rubro_id ?? producto.rubro_id;
-    producto.sistema_id = sistema_id ?? producto.sistema_id;
+    producto.rubro_id = rubro_id !== undefined ? rubro_id : producto.rubro_id;
+    producto.sistema_id = sistema_id !== undefined ? sistema_id : producto.sistema_id;
     producto.disponible = disponible ?? producto.disponible;
-    producto.proveedor_id = proveedor_id ?? producto.proveedor_id;
+    producto.proveedor_id = proveedor_id !== undefined ? proveedor_id : producto.proveedor_id;
 
     await productoRepository.save(producto);
 
@@ -364,10 +364,10 @@ export const crearProducto = async (req: Request, res: Response) => {
     nuevoProducto.precio = validarPrecio(precio, 'Crear Producto');
     nuevoProducto.divisa = divisa;
     nuevoProducto.descuento = descuento;
-    nuevoProducto.rubro_id = rubro_id;
-    nuevoProducto.sistema_id = sistema_id;
+    nuevoProducto.rubro_id = rubro_id || null;
+    nuevoProducto.sistema_id = sistema_id || null;
     nuevoProducto.disponible = disponible;
-    nuevoProducto.proveedor_id = proveedor_id;
+    nuevoProducto.proveedor_id = proveedor_id || null;
 
     // Guardar el nuevo producto en la base de datos
     await AppDataSource.getRepository(Producto).save(nuevoProducto);
@@ -477,19 +477,19 @@ export const importacionMasivaProductos = async (req: Request, res: Response) =>
         const descuento = row['descuento'] && !isNaN(Number(row['descuento'])) ? Number(row['descuento']) : 0;
         const disponible = row['disponible'] === 'SI' || row['disponible'] === 'si' || row['disponible'] === '1' || row['disponible'] === true;
 
-        let proveedor_id = 1;
+        let proveedor_id: number | null = null;
         const proveedorIdRaw = row['proveedor_id'] || row['Proveedor_id'];
         if (proveedorIdRaw && proveedorIdRaw !== '' && !isNaN(Number(proveedorIdRaw))) {
           proveedor_id = Number(proveedorIdRaw);
         }
 
-        let rubro_id = '';
+        let rubro_id: string | null = null;
         const rubroIdRaw = row['rubro_id'] || row['Rubro_id'];
         if (rubroIdRaw && rubroIdRaw !== '' && !isNaN(Number(rubroIdRaw))) {
           rubro_id = String(rubroIdRaw);
         }
 
-        let sistema_id = '';
+        let sistema_id: string | null = null;
         const sistemaIdRaw = row['sistema_id'] || row['Sistema_id'];
         if (sistemaIdRaw && sistemaIdRaw !== '' && !isNaN(Number(sistemaIdRaw))) {
           sistema_id = String(sistemaIdRaw);
@@ -639,7 +639,7 @@ export const corregirPreciosCero = async (req: Request, res: Response) => {
 };
 
 // Función auxiliar para obtener precio por defecto según rubro
-const obtenerPrecioPorDefecto = (rubroId: string): number => {
+const obtenerPrecioPorDefecto = (rubroId: string | null): number => {
   const preciosPorDefecto: { [key: string]: number } = {
     '1': 25000, // CONFECCIONES
     '2': 10000, // COLOCACIONES
@@ -651,5 +651,5 @@ const obtenerPrecioPorDefecto = (rubroId: string): number => {
     '8': 40000  // FLEXCOLOR
   };
   
-  return preciosPorDefecto[rubroId] || 25000; // Precio por defecto general
+  return (rubroId && preciosPorDefecto[rubroId]) ? preciosPorDefecto[rubroId] : 25000; // Precio por defecto general
 };

--- a/src/entities/Producto.ts
+++ b/src/entities/Producto.ts
@@ -6,41 +6,41 @@ export class Producto {
   @PrimaryGeneratedColumn()
   id!: number;
 
-  @Column()
+  @Column({ default: '' })
   nombreProducto!: string;
 
-  @Column()
+  @Column({ default: '0' })
   cantidad_stock!: string;
 
-  @Column()
+  @Column({ default: '' })
   descripcion!: string;
 
-  @Column()
+  @Column({ default: '0' })
   precioCosto!: string;
 
-  @Column()
+  @Column({ default: '0' })
   precio!: string;
 
-  @Column()
+  @Column({ default: 'ARS' })
   divisa!: string;
 
-  @Column()
+  @Column({ default: 0 })
   descuento!: number;
 
-  @Column()
-  rubro_id!: string;
+  @Column({ type: 'varchar', nullable: true })
+  rubro_id!: string | null;
 
-  @Column()
-  sistema_id!: string;
+  @Column({ type: 'varchar', nullable: true })
+  sistema_id!: string | null;
 
-  @Column()
+  @Column({ default: true })
   disponible!: boolean;
 
-  @Column()
-  proveedor_id!: number;
+  @Column({ type: 'int', nullable: true })
+  proveedor_id!: number | null;
 
-  @ManyToOne(() => Proveedores, (proveedor) => proveedor.productos)
+  @ManyToOne(() => Proveedores, (proveedor) => proveedor.productos, { nullable: true })
   @JoinColumn({ name: 'proveedor_id' })  // Especifica que la columna de clave foránea es 'proveedorid'
-  proveedor!: Proveedores;
+  proveedor!: Proveedores | null;
   // proveedor_id: any;
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make Producto relations (`rubro_id`, `sistema_id`, `proveedor_id`) nullable and add column defaults; adjust update/create/import flows and price helpers to handle null/undefined correctly.
> 
> - **Entities/DB Schema**:
>   - `Producto`:
>     - Set defaults for `nombreProducto`, `cantidad_stock`, `descripcion`, `precioCosto`, `precio`, `divisa`, `descuento`, `disponible`.
>     - Make `rubro_id`, `sistema_id` nullable (`varchar`), and `proveedor_id` nullable (`int`).
>     - Mark `@ManyToOne` `proveedor` relation as nullable.
> - **Controllers**:
>   - `actualizarProducto`: update `rubro_id`, `sistema_id`, `proveedor_id` only when not `undefined` (allow setting `null`).
>   - `crearProducto`: persist `rubro_id`, `sistema_id`, `proveedor_id` as provided or `null` when absent.
>   - Importación masiva: default `proveedor_id`, `rubro_id`, `sistema_id` to `null` when missing; types updated.
>   - Precios: `obtenerPrecioPorDefecto` accepts `rubroId: string | null` and safely falls back to default.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 122c956e09fc6052e4d81d372edfc3636f11cc00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->